### PR TITLE
Sourcing .bashrc

### DIFF
--- a/0.10/.sti/bin/assemble
+++ b/0.10/.sti/bin/assemble
@@ -5,7 +5,8 @@
 # application folder.
 [ -d "/usr/src/app" ] && exit 0
 
-source scl_source enable nodejs010
+# For SCL enablement
+source .bashrc
 
 set -e
 

--- a/0.10/.sti/bin/run
+++ b/0.10/.sti/bin/run
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-source scl_source enable nodejs010
+# For SCL enablement
+source .bashrc
 
 set -e
 


### PR DESCRIPTION
Enable the SCL's by sourcing `.bashrc` as suggested by @mfojtik in the last PR.
@mfojtik PTAL