### PR TITLE
Remove bashrc sourcing in STI scripts

### DIFF
--- a/0.10/.sti/bin/assemble
+++ b/0.10/.sti/bin/assemble
@@ -5,9 +5,6 @@
 # application folder.
 [ -d "/usr/src/app" ] && exit 0
 
-# For SCL enablement
-source .bashrc
-
 set -e
 
 if [ "$1" = "-h" ]; then

--- a/0.10/.sti/bin/run
+++ b/0.10/.sti/bin/run
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# For SCL enablement
-source .bashrc
-
 set -e
 
 # Runs the nodejs application server.

--- a/0.10/contrib/src/.bashrc
+++ b/0.10/contrib/src/.bashrc
@@ -1,2 +1,3 @@
 # This will make scl collection binaries work out of box.
+unset BASH_ENV
 source scl_source enable nodejs010

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,10 @@ endif
 
 .PHONY: build
 build:
-	hack/build.sh $(OS) $(VERSION)
+	SKIP_SQUASH=$(SKIP_SQUASH) hack/build.sh $(OS) $(VERSION)
 
 
 .PHONY: test
 test:
-	TEST_MODE=true hack/build.sh $(OS) $(VERSION)
+	SKIP_SQUASH=1 TEST_MODE=true hack/build.sh $(OS) $(VERSION)
+

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -29,7 +29,9 @@ function docker_build {
   fi
 
   docker build -t ${TAG} . && trap - ERR
-  squash
+  [ -z "${SKIP_SQUASH}" ] && squash
+
+  return 0
 }
 
 if [ -z ${VERSION} ]; then


### PR DESCRIPTION
For details, see: https://github.com/openshift/sti-base/pull/35