### PR TITLE
Remove MAINTAINER in RHEL image

### DIFF
--- a/0.10/Dockerfile.rhel7
+++ b/0.10/Dockerfile.rhel7
@@ -3,8 +3,6 @@ FROM openshift/base-rhel7
 # This image provides a Node.JS environment you can use to run your Node.JS
 # applications.
 
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 EXPOSE 8080
 
 ENV NODEJS_VERSION 0.10


### PR DESCRIPTION
It is recommended not to use MAINTAINER in RHEL images.