### PR TITLE
Preliminary PR for DEVEX-57

### DIFF
--- a/0.20/Dockerfile
+++ b/0.20/Dockerfile
@@ -1,0 +1,41 @@
+FROM openshift/base-centos7
+
+# This image provides a Node.JS environment you can use to run your Node.JS
+# applications.
+
+MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
+
+EXPOSE 8080
+
+ENV NODEJS_VERSION 0.10
+
+LABEL io.k8s.description="Platform for building and running Node.js 0.10 applications" \
+      io.k8s.display-name="Node.js 0.10" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.tags="builder,nodejs,nodejs010" \
+      io.openshift.dev-mode="NODE_ENV:development" \
+      io.openshift.deployments-dir="/opt/app-root/src" \
+      io.openshift.dev-mode.port="DEBUG_PORT:8787"
+
+RUN yum install -y \
+    https://www.softwarecollections.org/en/scls/rhscl/v8314/epel-7-x86_64/download/rhscl-v8314-epel-7-x86_64.noarch.rpm \
+    https://www.softwarecollections.org/en/scls/rhscl/nodejs010/epel-7-x86_64/download/rhscl-nodejs010-epel-7-x86_64.noarch.rpm && \
+    yum install -y --setopt=tsflags=nodocs nodejs010 && \
+    yum clean all -y
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Each language image can have 'contrib' a directory with extra files needed to
+# run and build the applications.
+COPY ./contrib/ /opt/app-root
+
+# Drop the root user and make the content of /opt/app-root owned by user 1001
+RUN chown -R 1001:0 /opt/app-root
+USER 1001
+
+# Add npm package binaries to PATH
+ENV PATH $PATH:/opt/app-root/src/node_modules/.bin
+
+# Set the default CMD to print the usage of the language image
+CMD $STI_SCRIPTS_PATH/usage

--- a/0.20/Dockerfile.rhel7
+++ b/0.20/Dockerfile.rhel7
@@ -1,0 +1,44 @@
+FROM openshift/base-rhel7
+
+# This image provides a Node.JS environment you can use to run your Node.JS
+# applications.
+
+EXPOSE 8080
+
+ENV NODEJS_VERSION 0.10
+
+LABEL io.k8s.description="Platform for building and running Node.js 0.10 applications" \
+      io.k8s.display-name="Node.js 0.10" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.tags="builder,nodejs,nodejs010" \
+      io.openshift.dev-mode="NODE_ENV:development" \
+      io.openshift.deployments-dir="/opt/app-root/src" \
+      io.openshift.dev-mode.port="DEBUG_PORT:8787"
+
+# Labels consumed by Red Hat build service
+LABEL BZComponent="nodejs010" \
+      Name="openshift3/nodejs-010-rhel7" \
+      Version="0.10" \
+      Release="1" \
+      Architecture="x86_64"
+
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+    yum-config-manager --enable rhel-7-server-optional-rpms && \
+    yum install -y --setopt=tsflags=nodocs nodejs010 && \
+    yum clean all -y
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Each language image can have 'contrib' a directory with extra files needed to
+# run and build the applications.
+COPY ./contrib/ /opt/app-root
+
+# Drop the root user and make the content of /opt/app-root owned by user 1001
+RUN chown -R 1001:0 /opt/app-root
+USER 1001
+
+ENV PATH $PATH:/opt/app-root/src/node_modules/.bin
+
+# Set the default CMD to print the usage of the language image
+CMD $STI_SCRIPTS_PATH/usage

--- a/0.20/README.md
+++ b/0.20/README.md
@@ -1,0 +1,114 @@
+NodeJS Docker image
+===================
+
+This repository contains the source for building various versions of
+the Node.JS application as a reproducible Docker image using
+[source-to-image](https://github.com/openshift/source-to-image).
+Users can choose between RHEL and CentOS based builder images.
+The resulting image can be run using [Docker](http://docker.io).
+
+What's new in 0.20?
+--------------------
+The new 0.20 image automatically runs the NodeJS app with [nodemon](https://github.com/remy/nodemon) if the OpenShift instance is in development mode. This emulates 'hot deploy', in which users can update code running in the Docker container and see changes instantly. 
+
+
+Usage
+---------------------
+To build a simple [nodejs-sample-app](https://github.com/openshift/sti-nodejs/tree/master/0.10/test/test-app) application
+using standalone [STI](https://github.com/openshift/source-to-image) and then run the
+resulting image with [Docker](http://docker.io) execute:
+
+*  **For RHEL based image**
+    ```
+    $ s2i build https://github.com/openshift/sti-nodejs.git --context-dir=0.20/test/test-app/ openshift/nodejs-020-rhel7 nodejs-sample-app
+    $ docker run -p 8080:8080 nodejs-sample-app
+    ```
+
+*  **For CentOS based image**
+    ```
+    $ s2i build https://github.com/openshift/sti-nodejs.git --context-dir=0.20/test/test-app/ openshift/nodejs-020-centos7 nodejs-sample-app
+    $ docker run -p 8080:8080 nodejs-sample-app
+    ```
+
+**Accessing the application:**
+```
+$ curl 127.0.0.1:8080
+```
+
+
+Repository organization
+------------------------
+* **`<nodejs-version>`**
+
+    * **Dockerfile**
+
+        CentOS based Dockerfile.
+
+    * **Dockerfile.rhel7**
+
+        RHEL based Dockerfile. In order to perform build or test actions on this
+        Dockerfile you need to run the action on a properly subscribed RHEL machine.
+
+    * **`s2i/bin/`**
+
+        This folder contains scripts that are run by [STI](https://github.com/openshift/source-to-image):
+
+        *   **assemble**
+
+            Used to install the sources into the location where the application
+            will be run and prepare the application for deployment (eg. installing
+            modules using npm, etc.)
+
+        *   **run**
+
+            This script is responsible for running the application, by using the
+            application web server.
+
+        *   **usage***
+
+            This script prints the usage of this image.
+
+    * **`contrib/`**
+
+        This folder contains a file with commonly used modules.
+
+    * **`test/`**
+
+        This folder contains the [S2I](https://github.com/openshift/source-to-image)
+        test framework with simple Node.JS echo server.
+
+        * **`test-app/`**
+
+            A simple Node.JS echo server used for testing purposes by the [S2I](https://github.com/openshift/source-to-image) test framework.
+
+        * **run**
+
+            This script runs the [S2I](https://github.com/openshift/source-to-image) test framework.
+
+
+Environment variables
+---------------------
+
+To set environment variables, you can place them as a key value pair into a `.sti/environment`
+file inside your source code repository.
+
+Example: DATABASE_USER=sampleUser
+
+Hot deploy
+---------------------
+As of 0.20, this image supports hot deploy.
+
+Hot deploy can be switched on and off with the environment variable `NODE_ENV`. An empty `NODE_ENV` value, or a value of `development`, will enable hot deploy.
+Hot deploy can be disabled by setting `NODE_ENV` to any non-empty value other than `development`.
+
+To change your source code in running container, you can use Docker's [exec](http://docker.io) command:
+```
+docker exec -it <CONTAINER_ID> /bin/bash
+```
+
+After you [Docker exec](http://docker.io) into the running container, your current directory is set to `/opt/app-root/src`, where the source code is located.
+
+If you have deployed the container to OpenShift, you can use [oc rsync](https://docs.openshift.org/latest/dev_guide/copy_files_to_container.html) to copy local files to a remote container running in an OpenShift pod. Examples of integrating this behaviour with Grunt and Gulp's _watch_ tasks can be found [here](./test/test-app).
+
+### **Warning**:
+Hot deploy is implemented with the default behaviour of nodemon. The default behaviour is to execute the main attribute of the _package.json_ file, and failing that, to execute the start script. In production mode, sti-nodejs will execute the start script via `npm start -d`. It is advised to remove the main attribute in the _package.json_ file when using hot deploy/development mode.

--- a/0.20/contrib/etc/npm_global_module_list
+++ b/0.20/contrib/etc/npm_global_module_list
@@ -1,0 +1,5 @@
+async
+mime
+mkdirp
+qs
+minimatch

--- a/0.20/contrib/etc/scl_enable
+++ b/0.20/contrib/etc/scl_enable
@@ -1,0 +1,3 @@
+# This will make scl collection binaries work out of box.
+unset BASH_ENV PROMPT_COMMAND ENV
+source scl_source enable nodejs010

--- a/0.20/s2i/bin/assemble
+++ b/0.20/s2i/bin/assemble
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Prevent running assemble in builders different than official STI image.
+# The official nodejs:0.10-onbuild already run npm install and use different
+# application folder.
+[ -d "/usr/src/app" ] && exit 0
+
+set -e
+
+# FIXME: Linking of global modules is disabled for now as it causes npm failures
+#        under RHEL7
+# Global modules good to have
+# npmgl=$(grep "^\s*[^#\s]" ../etc/npm_global_module_list | sort -u)
+# Available global modules; only match top-level npm packages
+#global_modules=$(npm ls -g 2> /dev/null | perl -ne 'print "$1\n" if /^\S+\s(\S+)\@[\d\.-]+/' | sort -u)
+# List all modules in common
+#module_list=$(/usr/bin/comm -12 <(echo "${global_modules}") | tr '\n' ' ')
+# Link the modules
+#npm link $module_list
+
+echo "---> Installing application source"
+cp -Rf /tmp/src/. ./
+
+echo "---> Building your Node application from source"
+npm install -d 
+[ "$NODE_ENV" == development ] && npm install nodemon
+
+# Fix source directory permissions
+fix-permissions ./

--- a/0.20/s2i/bin/run
+++ b/0.20/s2i/bin/run
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+echo "Running with NODE_ENV=$NODE_ENV"
+
+# Set the debug port to 5858 by default.
+if [ -z "$DEBUG_PORT" ]; then
+    DEBUG_PORT=5858
+fi
+
+# Set the environment to development by default.
+if [ -z "$NODE_ENV" ]; then
+    NODE_ENV=development    
+fi
+
+# Runs the nodejs application server. The sever is also run
+# with nodemon if the NODE_ENV environment variable is appropriately set.
+run_node() {
+  if [ $NODE_ENV == development ]; then
+      exec nodemon --debug=$DEBUG_PORT
+  else
+      exec npm start -d
+  fi
+} 
+
+# If the official dockerhub node image is used, skip the SCL setup below
+# and just run the nodejs server
+if [ -d "/usr/src/app" ]; then
+ run_node
+fi
+
+# Allow users to inspect/debug the builder image itself, by using:
+# $ docker run -i -t openshift/centos-nodejs-builder --debug
+#
+[ "$1" == "--debug" ] && exec /bin/bash
+
+run_node
+

--- a/0.20/s2i/bin/usage
+++ b/0.20/s2i/bin/usage
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+DISTRO=`cat /etc/*-release | grep ^ID= | grep -Po '".*?"' | tr -d '"'`
+
+cat <<EOF
+This is a S2I nodejs-0.10 ${DISTRO} base image:
+To use it, install S2I: https://github.com/openshift/source-to-image
+
+Sample invocation:
+
+s2i build https://github.com/openshift/sti-nodejs.git --context-dir=0.10/test/test-app/ openshift/nodejs-010-${DISTRO}7 nodejs-sample-app
+
+You can then run the resulting image via:
+docker run -p 8080:8080 nodejs-sample-app
+EOF

--- a/0.20/test/test-app/Gruntfile.js
+++ b/0.20/test/test-app/Gruntfile.js
@@ -1,0 +1,24 @@
+module.exports = function(grunt) {
+
+    grunt.initConfig({
+        shell: {
+            target: {
+                // For the oc rsync command to work, insert your pod id where POD-ID is.
+                // Note that if you're running multiple containers, you'll need to specify the
+                // right container with the -c flag. More information on how to do this can be found
+                // here: https://docs.openshift.org/latest/dev_guide/copy_files_to_container.html
+                command: "oc rsync . POD-ID:/opt/app-root/src"
+            }
+        },
+        watch: {
+            files: ['server.js'],
+            tasks: ['shell']
+        }
+    });
+
+    grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-shell');
+
+    grunt.registerTask('default', ['watch']);
+
+};

--- a/0.20/test/test-app/README.md
+++ b/0.20/test/test-app/README.md
@@ -1,0 +1,11 @@
+node-echo
+=========
+
+node.js echo server, returns request data to response
+
+## Using existing build tools
+
+### Integrating s2i-nodejs developer support with Grunt and Gulp
+You can use Grunti or Gulp to detect changes in your local directory and sync those changes to the code running in the remote docker container.
+_Gruntfile.js_ and _gulpfile.js_ provide apt examples for doing this. 
+

--- a/0.20/test/test-app/gulpfile.js
+++ b/0.20/test/test-app/gulpfile.js
@@ -1,0 +1,14 @@
+var gulp = require('gulp'),
+    watch = require('gulp-watch'),
+    shell = require('gulp-shell');
+
+// For the oc rsync command to work, insert your pod id where POD-ID is.
+// Note that if you're running multiple containers, you'll need to specify the
+// right container with the -c flag. More information on how to do this can be found
+// here: https://docs.openshift.org/latest/dev_guide/copy_files_to_container.html                                                 
+gulp.task('rsync', shell.task(['oc rsync . POD-ID:/opt/app-root/src']));
+
+gulp.task('default', function() {
+    gulp.watch(['*.js'], ['rsync'])
+});
+

--- a/0.20/test/test-app/iisnode.yml
+++ b/0.20/test/test-app/iisnode.yml
@@ -1,0 +1,27 @@
+# For documentation see https://github.com/tjanczuk/iisnode/blob/master/src/samples/configuration/iisnode.yml
+
+# loggingEnabled: false
+# debuggingEnabled: false
+# devErrorsEnabled: false
+node_env: production
+# nodeProcessCountPerApplication: 1
+# maxConcurrentRequestsPerProcess: 1024
+# maxNamedPipeConnectionRetry: 24
+# namedPipeConnectionRetryDelay: 250
+# maxNamedPipeConnectionPoolSize: 512
+# maxNamedPipePooledConnectionAge: 30000
+# asyncCompletionThreadCount: 0
+# initialRequestBufferSize: 4096
+# maxRequestBufferSize: 65536
+watchedFiles: iisnode.yml;node_modules\*;*.js
+# uncFileChangesPollingInterval: 5000
+# gracefulShutdownTimeout: 60000
+# logDirectoryNameSuffix: logs
+# debuggerPortRange: 5058-6058
+# debuggerPathSegment: debug
+# maxLogFileSizeInKB: 128
+# appendToExistingLog: false
+# logFileFlushInterval: 5000
+# flushResponse: false
+# enableXFF: false
+# promoteServerVars:  

--- a/0.20/test/test-app/package.json
+++ b/0.20/test/test-app/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "node-echo",
+  "version": "0.0.1",
+  "description": "node-echo",
+  "main": "server.js",
+  "dependencies": {},
+  "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-contrib-watch": "^0.6.1",
+    "gulp": "^3.9.0",
+    "gulp-shell": "^0.5.1",
+    "gulp-watch": "^4.3.5",
+    "nodemon": "*"
+  },
+  "engine": {
+    "node": "*",
+    "npm": "*"
+  },
+  "scripts": {
+    "dev": "nodemon --ignore node_modules/ server.js",
+    "start": "node --debug server.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/bettiolo/node-echo.git"
+  },
+  "keywords": [
+    "Echo"
+  ],
+  "author": "Marco Bettiolo <marco@bettiolo.it>",
+  "license": "",
+  "bugs": {
+    "url": "http://github.com/bettiolo/node-echo/issues"
+  },
+  "homepage": "http://apilb.com"
+}

--- a/0.20/test/test-app/web.config
+++ b/0.20/test/test-app/web.config
@@ -1,0 +1,17 @@
+<configuration>
+    <system.webServer>
+        <handlers>
+            <add name="iisnode" path="server.js" verb="*" modules="iisnode" />
+        </handlers>
+        <iisnode loggingEnabled="false" />
+
+        <rewrite>
+            <rules>
+                <rule name="myapp">
+                    <match url="/*" />
+                    <action type="Rewrite" url="server.js" />
+                </rule>
+            </rules>
+        </rewrite>
+    </system.webServer>
+</configuration>


### PR DESCRIPTION
@gorkem Can you take a look at this PR? This is only for [DEVEX-57](https://issues.jboss.org/browse/DEVEX-57) (DEVEX-43). 

Notes:
* Naming the directory/image 0.20 may be incorrect. It appears that 0.10 may have been named according to the Node.js version that it supports. The [sti-ruby](https://github.com/openshift/sti-ruby) repository uses 2.0 and 2.2, corresponding to ruby versions. It may be best to pull this into 0.10.
* The env variable for development mode has been intentionally chosen to be NODE_ENV. This limits modularity: if we want to do something in development mode and not produce other side effects that NODE_ENV produces, we are unable to. However, the question is whether or not we want to allow the two to diverge. Any side effects that the NODE_ENV produces, or could conceivably produce in the future, are side effects that we want, e.g. not copying devDependencies under production. Note, however, that NODE_ENV must be set to production. If NODE_ENV is also ever deprecated, we look slightly messy if we don't also keep up with the NODE_ENV replacement.
* I'm deciding to not link to a blog in the documentation in the repository. No real reason other than the blog hasn't yet been written.
* The `run` script doesn't read in the default values from the image. Should it? Is it even possible? the run script would then need to know the name of the image. That could be a bit messy.