### PR TITLE
Change Centos rpms to point to centos hosted collections instead of s…

### DIFF
--- a/0.10/Dockerfile
+++ b/0.10/Dockerfile
@@ -14,9 +14,7 @@ LABEL io.k8s.description="Platform for building and running Node.js 0.10 applica
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,nodejs,nodejs010"
 
-RUN yum install -y \
-    https://www.softwarecollections.org/en/scls/rhscl/v8314/epel-7-x86_64/download/rhscl-v8314-epel-7-x86_64.noarch.rpm \
-    https://www.softwarecollections.org/en/scls/rhscl/nodejs010/epel-7-x86_64/download/rhscl-nodejs010-epel-7-x86_64.noarch.rpm && \
+RUN yum install -y centos-release-scl && \
     yum install -y --setopt=tsflags=nodocs nodejs010 && \
     yum clean all -y
 


### PR DESCRIPTION
…oftwarecollections.org

From email on scl mailing list:
> Since the website softwarecollections.org has experienced troubles these 
days, I believe we can officially suggest using builds from CentOS Build 
System as the solution -- not only for now, but also for the future, 
because it would happen anyway.


Signed-off-by: Ian Stewart-Binks <istewart@redhat.com>