### PR TITLE
Add development mode for nodejs image

### DIFF
--- a/0.10/Dockerfile
+++ b/0.10/Dockerfile
@@ -12,7 +12,10 @@ ENV NODEJS_VERSION 0.10
 LABEL io.k8s.description="Platform for building and running Node.js 0.10 applications" \
       io.k8s.display-name="Node.js 0.10" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,nodejs,nodejs010"
+      io.openshift.tags="builder,nodejs,nodejs010" \
+      com.redhat.dev-mode="DEV_MODE:false" \
+      com.redhat.deployments-dir="/opt/app-root/src" \
+      com.redhat.dev-mode.port="DEBUG_PORT:5858"
 
 RUN yum install -y centos-release-scl && \
     yum install -y --setopt=tsflags=nodocs nodejs010 && \
@@ -24,6 +27,8 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Each language image can have 'contrib' a directory with extra files needed to
 # run and build the applications.
 COPY ./contrib/ /opt/app-root
+
+RUN $PROMPT_COMMAND && npm install -g nodemon
 
 # Drop the root user and make the content of /opt/app-root owned by user 1001
 RUN chown -R 1001:0 /opt/app-root

--- a/0.10/Dockerfile.rhel7
+++ b/0.10/Dockerfile.rhel7
@@ -11,7 +11,10 @@ LABEL summary="Platform for building and running Node.js 0.10 applications" \
       io.k8s.description="Platform for building and running Node.js 0.10 applications" \
       io.k8s.display-name="Node.js 0.10" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,nodejs,nodejs010"
+      io.openshift.tags="builder,nodejs,nodejs010" \
+      com.redhat.dev-mode="DEV_MODE:false" \
+      com.redhat.deployments-dir="/opt/app-root/src" \
+      com.redhat.dev-mode.port="DEBUG_PORT:5858"
 
 # Labels consumed by Red Hat build service
 LABEL com.redhat.component="nodejs010" \
@@ -23,6 +26,7 @@ LABEL com.redhat.component="nodejs010" \
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum install -y --setopt=tsflags=nodocs nodejs010 && \
+    yum install -y nodejs-nodemon && \
     yum clean all -y
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/0.10/contrib/etc/scl_enable
+++ b/0.10/contrib/etc/scl_enable
@@ -1,3 +1,23 @@
 # This will make scl collection binaries work out of box.
 unset BASH_ENV PROMPT_COMMAND ENV
 source scl_source enable nodejs010
+
+#Set the debug port to 5858 by default.
+if [ -z "$DEBUG_PORT" ]; then
+  export DEBUG_PORT=5858
+fi
+
+# Set the environment to development by default.
+if [ -z "$DEV_MODE" ]; then
+  export DEV_MODE=false
+fi
+
+# If NODE_ENV is not set by the user, then NODE_ENV is determined by whether
+# the container is run in development mode.
+if [ -z "$NODE_ENV" ]; then
+  if [ "$DEV_MODE" == true ]; then
+    export NODE_ENV=development
+  else
+    export NODE_ENV=production
+  fi
+fi

--- a/0.10/s2i/bin/run
+++ b/0.10/s2i/bin/run
@@ -2,10 +2,15 @@
 
 set -e
 
-# Runs the nodejs application server.
+# Runs the nodejs application server. If the container is run in development mode,
+# hot deploy and debugging are enabled.
 run_node() {
-  exec npm start -d
-}
+  if [ "$DEV_MODE" == true ]; then
+    exec nodemon --debug="$DEBUG_PORT"
+  else
+    exec npm start -d
+  fi
+} 
 
 # If the official dockerhub node image is used, skip the SCL setup below
 # and just run the nodejs server

--- a/0.10/test/run
+++ b/0.10/test/run
@@ -141,6 +141,78 @@ test_scl_usage() {
   fi
 }
 
+validate_default_value() {
+  local label=$1
+
+  IFS=':' read -a label_vals <<< $(docker inspect -f "{{index .Config.Labels \"$label\"}}" ${IMAGE_NAME}) 
+  label_var=${label_vals[0]}
+  default_label_val=${label_vals[1]}
+
+  actual_label_val=$(docker run --rm $IMAGE_NAME /bin/bash -c "echo $"$label_var)
+
+  if [ "$actual_label_val" != "$default_label_val" ]; then
+    echo "ERROR default value for $label with environment variable $label_var; Expected $default_label_val, got $actual_label_val"
+    return 1
+  fi
+}
+
+# Gets the NODE_ENV environment variable from the container.
+get_node_env_from_container() {
+  local dev_mode="$1"
+  local node_env="$2"
+
+  IFS=':' read -a label_val <<< $(docker inspect -f '{{index .Config.Labels "com.redhat.dev-mode"}}' $IMAGE_NAME)
+  dev_mode_label_var="${label_val[0]}"
+
+  echo $(docker run --rm --env $dev_mode_label_var=$dev_mode --env NODE_ENV=$node_env $IMAGE_NAME /bin/bash -c 'echo "$NODE_ENV"')
+}
+
+# Ensures that a docker container run with '--env NODE_ENV=$current_val' produces a NODE_ENV value of $expected when
+# DEV_MODE=dev_mode.
+validate_node_env() {
+  local current_val="$1"
+  local dev_mode_val="$2"
+  local expected="$3"
+
+  actual=$(get_node_env_from_container "$dev_mode_val" "$current_val")
+  if [ "$actual" != "$expected" ]; then
+    echo "ERROR default value for NODE_ENV when development mode is $dev_mode_val; should be $expected but is $actual"
+    return 1
+  fi
+}
+
+test_dev_mode_environment_variables() {
+  echo 'Testing Development Mode Environment Variable Setting...'
+ 
+  result=0
+ 
+  validate_default_value com.redhat.dev-mode
+  result=$(($result | $?))
+ 
+  validate_default_value com.redhat.dev-mode.port
+  result=$(($result | $?))
+
+  validate_node_env "" false production
+  result=$(($result | $?))
+
+  validate_node_env "" true development
+  result=$(($result | $?))
+
+  validate_node_env production false production
+  result=$(($result | $?))
+
+  validate_node_env production true production
+  result=$(($result | $?))
+
+  validate_node_env development false development
+  result=$(($result | $?))
+
+  validate_node_env development true development
+  result=$(($result | $?))
+  
+  return $result
+}
+
 # Build the application image twice to ensure the 'save-artifacts' and
 # 'restore-artifacts' scripts are working properly
 prepare
@@ -165,6 +237,9 @@ test_scl_usage "node --version" "v0.10"
 check_result $?
 
 test_connection
+check_result $?
+
+test_dev_mode_environment_variables
 check_result $?
 
 echo "Success!"


### PR DESCRIPTION
This pull request adds in a _development mode_ to the sti-nodejs docker image as per [this developer experience JIRA issue](https://issues.jboss.org/browse/DEVEX-43).

### "Hot Deploy"
_Development mode_ enables developers to run their applications using [nodemon](https://github.com/remy/nodemon) to help emulate hot-deploy and lets users specify the debug port upon running their docker image. Development mode should help guide future developer tooling, as well.

### Environment Variables/Developer Tooling Labels
This PR adds two new environment variables, `DEV_MODE` and `DEBUG_PORT` which are also added to the labels of the STI docker image, as per [this JIRA issue](https://issues.jboss.org/browse/CLOUD-243) (`com.redhat.dev-mode`, `com.redhat.dev-mode.port`) . The app's deployment directory is also a new label on the image, but has no corresponding environment variable (`com.redhat.deployments-dir`).

### A Note on Testing
The tests for this PR cover default environment variable setting, and ensure that the environment variables that are set match the environment variables that are specified in the corresponding `com.redhat.*` labels.

### Grunt/Gulp Integration With `oc rsync`/`watch`
The PR also adds in a _Gruntfile.js_ and a _gulpfile.js_, and documentation on how to use these command line tools to automatically sync their local source code to the code that's running in a remote container hosted on OpenShift.
*Edit: Removed. Grunt/Gulp Integration With `oc rsync`/`watch` will be put into a separate blog*

If you have any further questions, please do not hesitate to ask.