### PR TITLE
Adding ./node_modules/.bin to the $PATH to provide CLI access for npm scripts

### DIFF
--- a/0.10/Dockerfile
+++ b/0.10/Dockerfile
@@ -7,7 +7,10 @@ MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
 
 EXPOSE 8080
 
-ENV NODEJS_VERSION 0.10
+# Add $HOME/node_modules/.bin to the $PATH, allowing user to make npm scripts
+# available on the CLI without using npm's --global installation mode
+ENV NODEJS_VERSION=0.10 \
+    PATH=$HOME/node_modules/.bin/:$PATH
 
 LABEL io.k8s.description="Platform for building and running Node.js 0.10 applications" \
       io.k8s.display-name="Node.js 0.10" \

--- a/0.10/Dockerfile.rhel7
+++ b/0.10/Dockerfile.rhel7
@@ -5,7 +5,10 @@ FROM openshift/base-rhel7
 
 EXPOSE 8080
 
-ENV NODEJS_VERSION 0.10
+# Add $HOME/node_modules/.bin to the $PATH, allowing user to make npm scripts
+# available on the CLI without using npm's --global installation mode
+ENV NODEJS_VERSION=0.10 \
+    PATH=$HOME/node_modules/.bin/:$PATH
 
 LABEL summary="Platform for building and running Node.js 0.10 applications" \
       io.k8s.description="Platform for building and running Node.js 0.10 applications" \


### PR DESCRIPTION
For #87 (Needs testing) - I tried to follow the [build instructions](https://github.com/openshift/sti-nodejs#installation), but couldn't get them to work: (`lstat .sti/bin/: no such file or directory; hack/common.mk:21: recipe for target 'build' failed`)

This change *should* give users a way to make scripts "globally available" (CLI accessible)
Without requiring them to use admin-level system functions, like npm's "--global" installation mode.